### PR TITLE
ForwardDiff rules: uniform white noise

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "KroneckerProductKernels"
 uuid = "cdbd8a54-2c11-4475-85dd-323d022ca3c3"
-authors = ["Zach Langford <langfzac@sas.upenn.edu> and contributors"]
 version = "0.0.2"
+authors = ["Zach Langford <langfzac@sas.upenn.edu> and contributors"]
 
 [deps]
 AbstractGPs = "99985d1d-32ba-4be9-9821-2ec096f28918"
@@ -10,6 +10,12 @@ KernelFunctions = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
 Kronecker = "2c470bb0-bcc8-11e8-3dad-c9649493f05e"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[weakdeps]
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
+
+[extensions]
+KroneckerProductKernelsForwardDiffExt = "ForwardDiff"
 
 [compat]
 AbstractGPs = "0.5"

--- a/ext/KroneckerProductKernelsForwardDiffExt.jl
+++ b/ext/KroneckerProductKernelsForwardDiffExt.jl
@@ -1,0 +1,62 @@
+module KroneckerProductKernelsForwardDiffExt
+    using ForwardDiff, Kronecker, LinearAlgebra
+    using ForwardDiff: Dual, Partials, value, partials
+    using Kronecker: ⊗ 
+    import KroneckerProductKernels
+
+    # Compute quasi-analytic gradient using the method from Fortune et al. 2024
+    # This bypasses the need to differentiate the eigen decomposition
+    function KroneckerProductKernels._logpdf(
+        f::KroneckerProductKernels.UniformVarKroneckerFiniteGP, 
+        Y::AbstractVecOrMat{<:Real}, 
+        K::Kronecker.KroneckerProduct{D}
+        ) where D <: Dual
+        T = ForwardDiff.tagtype(D)
+        Np = ForwardDiff.npartials(D)
+        NM = size(Y,1)
+
+        # Extract primals for the Kronecker matrices
+        K1 = value.(K.A)
+        K2 = value.(K.B)
+
+        # Get the kronecker product matrix and compute the eigen decomposition of the components
+        E1 = eigen(Symmetric(K1)); Q1 = E1.vectors; Λ1 = Diagonal(E1.values)
+        E2 = eigen(Symmetric(K2)); Q2 = E2.vectors; Λ2 = Diagonal(E2.values)
+
+        # Get the K^-1 * Y
+        # Uses the "vec trick"
+        σ2 = value(f.Σy[1])
+        Λ = (Λ1 ⊗ Λ2) + σ2*I
+        invΛ = inv(Λ)
+        Q = (Q1 ⊗ Q2)
+        Qt = Q'
+        invKY = Q * invΛ * Qt * Y
+        invKYt = invKY'
+
+        # logpdf primal
+        logdetK = sum(log.(Λ.diag))
+        logpdf_val = -0.5 * (Y'invKY + logdetK + NM*log(2π))
+
+        # Compute gradients for each partial
+        grads = ntuple(Val(Np)) do i 
+            dK1 = partials.(K.A, i)
+            dK2 = partials.(K.B, i)
+            dΣ = partials.(f.Σy[1], i)
+
+            # Compute the quadratic term 
+            quad = invKYt * ((dK1 ⊗ K2) * invKY) + invKYt * ((K1 ⊗ dK2) * invKY)
+            
+            # Now the log determinant term
+            dlogdetK = dot(diag(invΛ), (diag(Q1' * dK1 * Q1) ⊗ diag(Q2' * K2 * Q2))) + dot(diag(invΛ), (diag(Q1' * K1 * Q1) ⊗ diag(Q2' * dK2 * Q2)))
+
+            # Handle the white noise parameter
+            if dΣ != 0.0
+                quad += dot(invKYt, invKY) * dΣ
+                dlogdetK += tr(invΛ) * dΣ
+            end
+
+            0.5 * (quad - dlogdetK)
+        end
+        return Dual{T}(logpdf_val, Partials(grads))
+    end
+end

--- a/src/gp.jl
+++ b/src/gp.jl
@@ -33,13 +33,17 @@ Random.rand(f::KroneckerFiniteGP, N::Int) = rand(Random.GLOBAL_RNG, f, N)
 Random.rand(rng::AbstractRNG, f::KroneckerFiniteGP) = vec(rand(rng, f, 1))
 Random.rand(f::KroneckerFiniteGP) = vec(rand(f, 1))
 
+function Distributions.logpdf(f::KroneckerFiniteGP, Y::AbstractVecOrMat{<:Real})
+    K = kernelmatrix(f.f.kernel, f.x)
+    return _logpdf(f, Y, K)
+end
+
 # Following Fortune et al. 2024
 # This one assumes uniform input variance -> f.Σy == σ²I
-function Distributions.logpdf(f::UniformVarKroneckerFiniteGP, Y::AbstractVecOrMat{<:Real})
+function _logpdf(f::UniformVarKroneckerFiniteGP, Y::AbstractVecOrMat{<:Real}, K)
     NM = size(Y,1)
 
     # Get the kronecker product matrix and compute the eigen decomposition of the components
-    K = kernelmatrix(f.f.kernel, f.x)
     E1 = eigen(Symmetric(K.A)); Q1 = E1.vectors; Λ1 = Diagonal(E1.values)
     E2 = eigen(Symmetric(K.B)); Q2 = E2.vectors; Λ2 = Diagonal(E2.values)
 
@@ -58,11 +62,8 @@ function Distributions.logpdf(f::UniformVarKroneckerFiniteGP, Y::AbstractVecOrMa
 end
 
 # Now for Σ is diagonal
-function Distributions.logpdf(f::DiagonalVarKroneckerFiniteGP, Y::AbstractVecOrMat{<:Real})
+function _logpdf(f::DiagonalVarKroneckerFiniteGP, Y::AbstractVecOrMat{<:Real}, K)
     NM = size(Y, 1)
-
-    # Get kernel matrix
-    K = kernelmatrix(f.f.kernel, f.x)
 
     # Get input covariance components
     Σ1 = f.Σy.A; Σ1m = inv(sqrt(Σ1))

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,6 +2,8 @@
 AbstractGPs = "99985d1d-32ba-4be9-9821-2ec096f28918"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
+FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 KernelFunctions = "ec8451be-7e33-11e9-00cf-bbf324bd1392"
 Kronecker = "2c470bb0-bcc8-11e8-3dad-c9649493f05e"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,6 +3,7 @@ using Test, BenchmarkTools, Random
 using KernelFunctions: TestUtils
 using KroneckerProductKernels: make_test_inputs
 using Kronecker: ⊗, Diagonal
+using ForwardDiff, FiniteDiff
 
 @testset "KroneckerProductKernels.jl" begin
     include("test_kernel.jl")

--- a/test/test_gp.jl
+++ b/test/test_gp.jl
@@ -62,6 +62,7 @@
     @testset "logpdf" begin
         # Test the logpdfs for a few combinations of kernels
         # Again, the computations for the tensor product kernel should match
+        rng = Random.MersenneTwister(1234)
         N, M = 100, 5
         X = make_test_inputs(N,M)
         kernels = (ExponentialKernel(), SqExponentialKernel(), Matern52Kernel(), WhiteKernel())
@@ -88,6 +89,41 @@
                     # Check type stability
                     @test @inferred(logpdf(fx_kron, Y)) isa Float64
                     @test @inferred(logpdf(fx_kron_scaled, Y)) isa Float64
+
+                    # Now test ForwardDiff (WhiteKernel is unstable)
+                    if (covariance isa Number) && (k1 != WhiteKernel()) && (k2 != WhiteKernel())
+                        function compute_logpdf(θ)
+                            h2, l1, l2, σ2 = θ
+                            k1_t = h2 * (k1 ∘ ScaleTransform(1 / l1))
+                            k2_t = (k2 ∘ ScaleTransform(1 / l2))
+                            fx = GP(KernelKroneckerProduct(k1_t, k2_t))(RowVecs(X), σ2)
+                            return logpdf(fx, Y)
+                        end
+
+                        for _ in 1:5
+                            θ = [
+                                rand(rng, Uniform(0.1, 5.0)),
+                                rand(rng, Uniform(1.0, 10.0)),
+                                rand(rng, Uniform(0.1, 1.0)),
+                                rand(rng, Uniform(0.1, 1.0))
+                            ]
+                            grad_AD = ForwardDiff.gradient(compute_logpdf, θ)
+                            grad_num = FiniteDiff.finite_difference_gradient(compute_logpdf, θ)
+                            if isapprox(grad_AD, grad_num, norm=x->maximum(abs.(x)))
+                                @test true
+                            elseif isapprox(grad_AD, grad_num, norm=x->maximum(abs.(x)), atol=1e-5)
+                                @info k1
+                                @info k2
+                                @info "Grad matches with atol=1e-5"
+                                @test true
+                            else
+                                @info k1
+                                @info k2
+                                @info maximum(abs.(grad_AD .- grad_num))
+                                @test isapprox(grad_AD, grad_num, norm=x->maximum(abs.(x)))
+                            end
+                        end
+                    end
 
                     # Report benchmarks
                     #=@info k_kron.kernels covariance


### PR DESCRIPTION
Add ForwardDiff rules the leverage analytic derivatives for stability (like `luas`) for the added uniform white noise case.